### PR TITLE
fix problem with GetJsonObject()

### DIFF
--- a/JsonHelper.cs
+++ b/JsonHelper.cs
@@ -100,11 +100,11 @@ namespace Demot.RandomOrgApi
         }
 
         public static JsonObject GetJsonObject(JsonObject obj, string path) {
-            JsonObject current = obj;
+            JsonObject current = null;
             var pathSections = path.Split('.');
             for(int i = 0; i < pathSections.Length; i++) {
                 object value;
-                if(current.TryGetValue(pathSections[i], out value)) {
+                if(obj.TryGetValue(pathSections[i], out value)) {
                     if(value is JsonObject) {
                         current = value as JsonObject;
                         continue;


### PR DESCRIPTION
When I was using this library to make a software, I encountered a problem with GetJsonObject function, in which an exception occurred when trying to get field name 'error' in an Json object that have no such field. I think there was a logic problem in the function, and I made a modification to it trying to solve the problem. I'm not totally sure I made the modification right, but after I made this modification it works well now. Please check it, thank you.
